### PR TITLE
Integrate GoatCounter and display resume download count on landing page

### DIFF
--- a/PROJECT_ENHANCEMENTS.md
+++ b/PROJECT_ENHANCEMENTS.md
@@ -1,0 +1,113 @@
+# Project Enhancement Recommendations
+
+This document captures practical improvements for the resume project across content quality, maintainability, automation, and discoverability.
+
+## 1) Resume Content Enhancements
+
+### 1.1 Add measurable outcomes consistently
+- Several experience bullets are strong, but not all include a clear metric.
+- Improve every bullet by adding at least one of: latency reduction, cost savings, incidents reduced, deployment frequency, or adoption impact.
+
+### 1.2 Strengthen ATS keyword alignment
+- Add/normalize common role keywords near experience and skills:
+  - "Distributed Systems", "System Design", "Observability", "REST APIs", "Cloud Architecture", "SRE", "CI/CD", "Microservices".
+- Keep wording natural while improving machine parsing.
+
+### 1.3 Rebalance "Skills" evidence
+- The "Over 5000 lines" and "Over 2000 lines" descriptors are unusual and can look arbitrary.
+- Replace with confidence signals such as:
+  - "Production use" / "Advanced" / "Working knowledge"
+  - or context tags (e.g., "Used in fintech production systems").
+
+### 1.4 Improve section prioritization for target roles
+- For backend/platform roles: keep Work Experience first, then Projects, Skills, Education.
+- For full-stack roles: keep Work Experience first, then Skills, Projects, Education.
+- Move lower-signal sections (e.g., broad coursework/fun facts) lower when space is tight.
+
+### 1.5 Make project section achievement-first
+- Current projects are mostly link listings.
+- Add one-line impact per key project (problem solved + stack + result), while keeping concise.
+
+## 2) LaTeX / Template Quality Enhancements
+
+### 2.1 Add configurable profile variants
+- Support multiple build targets (e.g., `backend`, `fullstack`, `general`) with conditional sections.
+- This avoids manually editing a single `.tex` file for each job application.
+
+### 2.2 Externalize reusable content
+- Move major sections (experience/projects/skills) into separate files and `\input{}` them.
+- Benefits: cleaner diffs, easier review, fewer merge conflicts.
+
+### 2.3 Clean minor formatting artifacts
+- Remove stray trailing backslash in Tools/Platforms section.
+- Normalize punctuation and spacing around links/titles for visual consistency.
+
+### 2.4 Improve typography and readability
+- Slightly increase spacing between dense bullet items in long experience blocks.
+- Consider reducing all-caps usage for section subheads if readability suffers on ATS exports.
+
+## 3) CI/CD and Repository Enhancements
+
+### 3.1 Update README to reflect current filenames
+- README still references a different root file (`dhirendra-pratap-singh-resume.tex`).
+- Sync setup instructions with current filenames to avoid onboarding confusion.
+
+### 3.2 Add local build helper
+- Provide a `Makefile` or script with:
+  - `make build`
+  - `make clean`
+  - `make watch` (optional)
+- This standardizes local compilation and reduces setup friction.
+
+### 3.3 Add quality gates in CI
+- Add checks for:
+  - successful XeLaTeX compile,
+  - broken URLs (optional link checker),
+  - and basic spellcheck for markdown/resume text.
+
+### 3.4 Add release artifact naming strategy
+- Publish canonical filename (e.g., `resume.pdf`) and optionally date-stamped copies.
+- Keep public URL stable while preserving historical snapshots.
+
+## 4) Web Presence / UX Enhancements
+
+### 4.1 Replace redirect-only `index.html` with resume landing page
+- Instead of immediate redirect, provide:
+  - short intro,
+  - "Download PDF" button,
+  - links to GitHub/LinkedIn/portfolio,
+  - last updated date.
+- Better branding and shareability.
+
+### 4.2 Add Open Graph metadata
+- Improve social sharing previews for `resume.hanisntsolo.com`.
+
+### 4.3 Add lightweight analytics (privacy-friendly)
+- Track resume downloads and visit source channels (optional).
+
+## 5) Suggested Implementation Plan (Prioritized)
+
+1. **Quick wins (1-2 hours)**
+   - README filename/path correction.
+   - Fix minor LaTeX formatting artifacts.
+   - Improve 3-5 bullets with stronger metrics.
+
+2. **Medium impact (half-day)**
+   - Add project one-liners with outcomes.
+   - Build helper (`Makefile`).
+   - Introduce CI link/spell checks.
+
+3. **High leverage (1 day)**
+   - Modularize resume content with `\input{}`.
+   - Add profile-specific compile targets (`backend`, `fullstack`).
+   - Upgrade `index.html` to a proper landing page.
+
+## 6) Optional Advanced Enhancements
+
+- Generate role-specific PDFs automatically using GitHub Actions matrix builds.
+- Add JSON/YAML source-of-truth + template generation for resume variants.
+- Add "evidence links" in bullets for selected achievements (talks, demos, docs).
+
+---
+
+If you want, I can implement the **quick wins** first in a focused follow-up change set.

--- a/README.md
+++ b/README.md
@@ -1,202 +1,70 @@
-[![First-Time Setup Hanisntsolo](https://github.com/hanisntsolo/resume/actions/workflows/first-time-setup-hanisntsolo.yml/badge.svg?branch=hanisntsolo)](https://github.com/hanisntsolo/resume/actions/workflows/first-time-setup-hanisntsolo.yml)
-[![Compile LaTeX document for Hanisntsolo](https://github.com/hanisntsolo/resume/actions/workflows/compile-latex-hanisntsolo.yml/badge.svg?branch=hanisntsolo)](https://github.com/hanisntsolo/resume/actions/workflows/compile-latex-hanisntsolo.yml)
-[![Compile LaTeX document](https://github.com/hanisntsolo/resume/actions/workflows/compile-latex.yml/badge.svg?branch=master)](https://github.com/hanisntsolo/resume/actions/workflows/compile-latex.yml) [![pages-build-deployment](https://github.com/hanisntsolo/resume/actions/workflows/pages/pages-build-deployment/badge.svg?branch=master)](https://github.com/hanisntsolo/resume/actions/workflows/pages/pages-build-deployment)
-# The Resume Project
+# Resume (LaTeX + GitHub Pages)
 
-This repository contains the LaTeX source files for my resume and is set up to automatically compile and deploy the resume to GitHub Pages using GitHub Actions.
+Personal resume source built with XeLaTeX and published to GitHub Pages.
 
-## Steps to Set Up
+## Repository Structure
 
-### 1. Clone the Repository
+- `hanisntsolo-resume.tex` — main resume source.
+- `hanisntsolo-resume.cls` — custom style class.
+- `index.html` — landing page with resume download and analytics hooks.
+- `output/` — generated artifacts (PDF output target).
+- `assets/` — logo/assets used in resume.
 
-Clone the repository to your local machine:
+## Local Build
 
-```bash
-git clone https://github.com/hanisntsolo/resume.git
-cd resume
-```
-
-### 2. Set Up GitHub Actions Workflow
-
-Create a GitHub Actions workflow to compile the LaTeX document and deploy it to GitHub Pages.
-
-Create a file `.github/workflows/deploy.yml` with the following content:
-
-```yaml
-name: Compile LaTeX document
-
-on:
-  push:
-    branches:
-      - master
-
-permissions:
-  contents: write  # Explicitly set the permission for the GITHUB_TOKEN
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Set up LaTeX
-        uses: xu-cheng/latex-action@v2
-        with:
-          root_file: dhirendra-pratap-singh-resume.tex
-          compiler: xelatex
-          args: -output-directory=output  # Specify output directory
-          
-      - name: Copy index.html to output
-        run: cp index.html output/index.html  # Copy index.html to output directory
-        
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./output  # Directory containing your compiled PDF
-          destination_dir: ./  # Directory where the site will be hosted
-```
-
-### 3. Enable GitHub Pages
-
-Go to the repository settings on GitHub and navigate to "Settings" > "Pages". Ensure the source is set to the `gh-pages` branch and the folder is `/ (root)`.
-
-### 4. Verify File Placement
-
-Ensure the compiled PDF is located at:
-
-```
-https://hanisntsolo.github.io/resume/dhirendra-pratap-singh-resume.pdf
-```
-
-### 5. Create a Redirect `index.html`
-
-Create an `index.html` file to redirect from `https://hanisntsolo.github.io/resume` to the PDF file.
+### Option 1: latexmk (recommended)
 
 ```bash
-# Ensure you are on the gh-pages branch
-git checkout gh-pages
-
-# Navigate to the resume directory
-cd resume
-
-# Create the index.html file
-echo '<!DOCTYPE html>
-<html>
-<head>
-    <meta http-equiv="refresh" content="0; url=dhirendra-pratap-singh-resume.pdf">
-    <title>Redirecting...</title>
-</head>
-<body>
-    <p>Redirecting to <a href="dhirendra-pratap-singh-resume.pdf">dhirendra-pratap-singh-resume.pdf</a></p>
-</body>
-</html>' > index.html
-
-# Add and commit the file
-git add index.html
-git commit -m "Add index.html for redirecting to renamed PDF"
-
-# Push the changes
-git push origin gh-pages
+latexmk -xelatex -output-directory=output hanisntsolo-resume.tex
 ```
 
-### Access the PDF
+### Option 2: xelatex directly
 
-- **Direct PDF URL:** `https://hanisntsolo.github.io/resume/dhirendra-pratap-singh-resume.pdf`
-- **Redirect URL:** `https://hanisntsolo.github.io/resume`
+```bash
+xelatex -output-directory=output hanisntsolo-resume.tex
+```
 
-### Clearing Browser Cache
+Generated PDF:
 
-If you face any issues with redirection, try clearing your browser cache or accessing the URL in an incognito window.
+- `output/hanisntsolo-resume.pdf`
 
-### Summary
+## Deploy to GitHub Pages
 
-This setup ensures that the LaTeX document for your resume is automatically compiled and deployed to GitHub Pages. The compiled PDF is accessible at the specified URL, with an `index.html` file ensuring a smooth redirection.
+In your workflow, compile the `.tex` file and publish `output/`.
 
-By following these steps, you can maintain and update your resume efficiently.
+Example key settings:
 
+- `root_file: hanisntsolo-resume.tex`
+- `compiler: xelatex`
+- `args: -output-directory=output`
+- copy `index.html` into `output/`
 
+## Analytics for Resume Downloads
 
-Deedy-Resume
-=========================
+You asked a great question: **yes, analytics needs a central counter/data sink**.
 
-A **one-page**, **two asymmetric column** resume template in **XeTeX** that caters particularly to an **undergraduate Computer Science** student.
-As of **v1.2**, there is an option to choose from two templates:
+You have 3 practical options:
 
-1. **MacFonts** - uses fonts native to OSX - *Helvetica*, *Helvetica Neue* (and it's Light and Ultralight versions) and the CJK fonts *Heiti SC*, and *Heiti TC*. The EULA of these fonts prevents distribution on Open Source.
-2. **OpenFonts** - uses free, open-source fonts that resemble the above - *Lato* (and its various variants) and *Raleway*.
+1. **Hosted analytics (fastest): GoatCounter (already wired)**
+   - `index.html` now includes your GoatCounter script snippet.
+   - Download button logs a dedicated event path: `/resume-download`.
+   - The landing page also attempts to fetch and show total download clicks from GoatCounter's counter endpoint.
 
-It is licensed under the Apache License 2.0.
+2. **Custom endpoint (most control)**
+   - If you want full ownership, replace the `loadDownloadCount()` fetch URL and event writer with your own API endpoint.
+   - Store counts in Redis/PostgreSQL (or serverless DB) and expose your own dashboard.
 
-## Motivation
+3. **Cloudflare Analytics / edge logs (low effort, coarse-grained)**
+   - Useful for total traffic trends.
+   - Not as explicit as click-level events unless custom event collection is added.
 
-Common LaTeX resume-builders such as [**moderncv**](http://www.latextemplates.com/template/moderncv-cv-and-cover-letter)  and the [**friggeri-cv**](https://github.com/afriggeri/cv) look great if you're looking for a multi-page resume with numerous citations, but usually imperfect for making a thorough, single-page one. A lot of companies today search resumes based on [keywords](http://www.businessinsider.com/most-big-companies-have-a-tracking-system-that-scans-your-resume-for-keywords-2012-1) but at the same time require/prefer a one-page resume, especially for undergraduates. 
+### Recommended setup for your use case
 
-This template attempts to **look clean**, highlight **details**, be a **single page**, and allow useful **LaTeX templating**.
+- GoatCounter is now the default tracking implementation in this repo.
+- If public counter endpoint is restricted, you will still see exact numbers in GoatCounter dashboard.
+- For guaranteed public count display on the page, either enable GoatCounter public counter endpoint or add a tiny proxy endpoint.
 
-## Preview
+## Notes
 
-### OpenFonts
-![alt tag](https://raw.githubusercontent.com/deedydas/Deedy-Resume/master/OpenFonts/sample-image.png)
-
-### MacFonts
-![alt tag](https://raw.githubusercontent.com/deedydas/Deedy-Resume/master/MacFonts/sample-image.png)
-
-## Dependencies
-
-1. Compiles only with **XeTeX** and required **BibTex** for compiling publications and the .bib filetype.
-2. Uses fonts that are usually only available to **Mac** users such as Helvetica Neue Light.
-
-## Availability
-
-1. MacFonts version - [as an online preview](http://debarghyadas.com/resume/debarghya-das-resume.pdf) and [as a direct download](https://github.com/deedydas/Deedy-Resume/raw/master/MacFonts/deedy_resume.pdf)
-2. OpenFonts version - [as a direct download](https://github.com/deedydas/Deedy-Resume/raw/master/OpenFonts/deedy_resume-openfont.pdf)
-3. **Overleaf**.com (formerly **WriteLatex**.com) (v1 fonts/colors changed) - [compilable online](https://www.writelatex.com/templates/deedy-resume/sqdbztjjghvz#.U2H9Kq1dV18)
-4. **ShareLatex**.com (v1 fonts changes) - [compilable online](https://www.sharelatex.com/templates/cv-or-resume/deedy-resume)
-
-## Changelog
-### v1.2
- 1. Added publications in place of societies.
- 2. Collapsed a portion of education.
- 3. Fixed a bug with alignment of overflowing long last updated dates on the top right. 
- 4. Github Pages is being used for serving the generated pdf's.
-
-### v1.1
- 1. Fixed several compilation bugs with \renewcommand
- 2. Got Open-source fonts (Windows/Linux support)
- 3. Added Last Updated
- 4. Moved Title styling into .sty
- 5. Commented .sty file.
-
-## TODO
-1. Merge OpenFont and MacFonts as a single sty with options.
-2. Figure out a smoother way for the document to flow onto the next page.
-3. Add styling information for a "Projects/Hacks" section.
-4. Add location/address information
-5. Fix the hacky 'References' omission outside the .cls file in the MacFonts version.
-6. Add various styling and section options and allow for multiple pages smoothly.
-
-## Known Issues:
-1. Overflows onto second page if any column's contents are more than the vertical limit
-2. Hacky space on the first bullet point on the second column.
-3. Hacky redefinition of \refname to omit 'References' text for publications in the MacFonts version.
-
-## Notes for me:
-1. Make master default when working on feature implementations.
-
-## License
-    Copyright 2014 Debarghya Das
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+- Resume content is tuned for one-page density; avoid adding long paragraphs.
+- Prefer impact-oriented bullets (action + tech + measurable outcome).

--- a/hanisntsolo-resume.tex
+++ b/hanisntsolo-resume.tex
@@ -85,23 +85,22 @@
 
 \section{Skills}
 {\subsection{Private Cloud}}
-\href{https://dozzle.hanisntsolo.com}{\location{With 32+ Services and Adv. Tooling}}
+\href{https://dozzle.hanisntsolo.com}{\location{Operating 32+ self-hosted services with observability}}
 \textbf{Docker} \textbullet{} Nginx \textbullet{} CI/CD
 \subsection{Languages}
-\location{Over 5000: lines}
+\location{Production-focused: Java, Python, TypeScript}
 \textbf{Java} \textbullet{} Python \textbullet{} \textbf{TypeScript} \\
 JavaScript \textbullet{} C \textbullet{} C++ \textbullet{} HTML \textbullet{} CSS
 
 \subsection{Frameworks}
-\location{Over 2000: lines}
+\location{Distributed systems, APIs, and web applications}
 \textbf{Apache Kafka} \textbullet{} ReactJS \textbullet{} Spring Boot \\
-Shedlock \textbullet{} \textbf{NextJS} \textbullet{} Shell Scripting \\
+ShedLock \textbullet{} \textbf{NextJS} \textbullet{} Shell Scripting \\
 % Docusaurus
 
 \subsection{Tools/Platforms}
 GCP \textbullet{} OCI \textbullet{} Microsoft Flow \\
 PostgreSQL \textbullet{} MySQL \textbullet{} Git \textbullet{} Jenkins
-\
 
 \sectionsep
 
@@ -138,20 +137,20 @@ Pinterest:\href{https://in.pinterest.com/hanisntoslo/boards/}{\bf hanisntsolo}
 %     COURSEWORK
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\section{Coursework}
-\subsection{Graduate}
-Cloud Computing |
-Machine Learning |
-Open Source Software Engineering |
-AI Integrations |
-Object-Oriented Programming \\
+% \section{Coursework}
+% \subsection{Graduate}
+% Cloud Computing |
+% Machine Learning |
+% Open Source Software Engineering |
+% AI Integrations |
+% Object-Oriented Programming \\
 
-\subsection{Undergraduate}
-Operating Systems |
-Artificial Intelligence + Practicum |
-Unix Tools and Scripting |
-Information Retrieval
-\sectionsep
+% \subsection{Undergraduate}
+% Operating Systems |
+% Artificial Intelligence + Practicum |
+% Unix Tools and Scripting |
+% Information Retrieval
+% \sectionsep
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -204,7 +203,7 @@ Information Retrieval
 
 \item Led VM-to-cloud migration efforts with auto-scaling and load-based billing optimizations, reducing infrastructure costs and improving deployment agility.
 
-\item Built and launched \textbf{UserManagement Pulse}, a full-stack internal product (React, Node, Java microservices), independently owning end-to-end lifecycle from architecture to CI/CD deployment.
+\item Built and launched \textbf{UserManagement Pulse}, a full-stack internal product (React, Node, Java microservices), owning architecture, implementation, and CI/CD rollout to accelerate internal issue resolution workflows.
 
 \item Documented system architecture and operational playbooks using \textbf{Docusaurus}, improving debugging efficiency and cross-team self-service enablement.
 
@@ -229,7 +228,7 @@ Full-stack contributions in ReactJS, Spring Boot, and PostgreSQL.
 \descript{| Remote Software Engineering Intern }
 \location{May 2020 – Aug 2020 | Atlanta, GA, USA}
 \begin{tightemize}
-\item Full-stack development of an e-commerce platform using ReactJS and Firebase. Integrating online payments via Stripe API and managed segregated customer/admin routes.
+\item Built core e-commerce workflows using ReactJS and Firebase, integrated Stripe payments, and implemented role-based customer/admin routing for secure operations.
 \end{tightemize}
 % \sectionsep
 
@@ -238,14 +237,20 @@ Full-stack contributions in ReactJS, Spring Boot, and PostgreSQL.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \section{Personal Projects \small\faExternalLink*}
-% \href{https://faangcracker.hanisntsolo.com/}{\runsubsection{FAANG-CRACKER}}
-\descript{
-\href{https://dozzle.hanisntsolo.com/}{\runsubsection{PRIVATE CLOUD 32+ Services}} |
-\href{https://faangcracker.hanisntsolo.com/}{\runsubsection{FAANG-CRACKER}} |
-\href{https://github.com/hanisntsolo/resume}{\runsubsection{GitHub Resume` Project}} |
-\href{https://github.com/hanisntsolo/codeforces-lamp}{\runsubsection{Codeforces Lamp}} |
-\href{https://github.com/hanisntsolo/auto-committer}{\runsubsection{Auto-committer}}
-}
+\runsubsection{Private Cloud (32+ Services)} \descript{| Docker, Nginx, CI/CD, Monitoring}
+\begin{tightemize}
+\item Built a self-hosted engineering cloud with observability and service isolation, improving release control and reducing dependency on third-party hosted tooling.
+\end{tightemize}
+
+\runsubsection{Rippler} \descript{| AI-Powered PR Impact Analysis Platform}
+\begin{tightemize}
+\item Designed an LLM-assisted impact analysis workflow to detect downstream service risks from code changes and speed up review decisions for microservice teams.
+\end{tightemize}
+
+\runsubsection{FAANG-CRACKER} \descript{| Next.js, Node.js, WebSockets}
+\begin{tightemize}
+\item Building an interview-prep platform with real-time coding workflows and problem tracking inspired by competitive programming systems.
+\end{tightemize}
 % \descript{| \href{https://faangcracker.hanisntsolo.com/}{Coding Tool (In Progress)} | \href{https://faangcracker.hanisntsolo.com/}{Check it out!} }
 % \begin{tightemize}
 % \item Developing a tool to automate FAANG interview prep, integrating Codeforces and LeetCode APIs. Built with Next.js, Node.js, and WebSocket support for code compilation in Java, Python, C++, and JavaScript.

--- a/index.html
+++ b/index.html
@@ -1,117 +1,150 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
-    <title>Redirecting...</title>
-    <style>
-        /* Basic reset */
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dhirendra Pratap Singh | Resume</title>
+  <meta name="description" content="Resume of Dhirendra Pratap Singh - Full Stack Java Developer focused on distributed systems and cloud-native engineering." />
+  <meta property="og:title" content="Dhirendra Pratap Singh | Resume" />
+  <meta property="og:description" content="Download resume and explore engineering profiles and links." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://resume.hanisntsolo.com/" />
+  <script data-goatcounter="https://hanisntsolo.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  <style>
+    :root {
+      --bg: #0b1220;
+      --card: #121a2b;
+      --text: #e8edf7;
+      --muted: #9fb0cf;
+      --accent: #5eead4;
+      --accent-2: #60a5fa;
+      --border: #26324b;
+    }
 
-        /* Full-screen container */
-        body,
-        html {
-            height: 100%;
-            width: 100%;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            background-color: black;
-            overflow: hidden;
-            color: white;
-            font-family: Arial, sans-serif;
-        }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Inter, Segoe UI, Roboto, Arial, sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at 20% 10%, #1a2440 0%, var(--bg) 55%);
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
 
-        .container {
-            position: relative;
-            width: 100%;
-            height: 100%;
-            overflow: hidden;
-        }
+    .card {
+      width: min(760px, 100%);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));
+      backdrop-filter: blur(4px);
+      padding: 28px;
+      box-shadow: 0 16px 36px rgba(0,0,0,0.3);
+    }
 
-        .stars {
-            width: 100%;
-            height: 100%;
-            background: black;
-            overflow: hidden;
-            position: absolute;
-        }
+    h1 { margin: 0 0 8px; font-size: clamp(1.6rem, 3vw, 2rem); }
+    .subtitle { margin: 0 0 20px; color: var(--muted); line-height: 1.5; }
 
-        .star {
-            position: absolute;
-            background: white;
-            width: 2px;
-            height: 2px;
-            border-radius: 50%;
-            animation: starMove 1.5s linear infinite;
-            /* Animation duration */
-        }
+    .buttons { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 18px; }
 
-        @keyframes starMove {
-            from {
-                transform: translate3d(0, 0, 0);
-                opacity: 1;
-            }
+    .btn {
+      border: 1px solid var(--border);
+      color: var(--text);
+      text-decoration: none;
+      padding: 11px 16px;
+      border-radius: 10px;
+      font-weight: 600;
+      transition: transform .12s ease, border-color .12s ease;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
 
-            to {
-                transform: translate3d(1000px, 0, 500px);
-                opacity: 0;
-            }
-        }
+    .btn:hover { transform: translateY(-1px); border-color: var(--accent-2); }
+    .btn.primary { background: linear-gradient(90deg, #0ea5a2, #3b82f6); border: none; }
 
-        .message {
-            position: absolute;
-            bottom: 20px;
-            width: 100%;
-            text-align: center;
-            font-size: 1.5em;
-            opacity: 1;
-            /* Keep it visible */
-            animation: none;
-            /* Remove fade in animation */
-        }
+    .links { display: flex; flex-wrap: wrap; gap: 14px; color: var(--muted); font-size: 0.95rem; }
+    .links a { color: var(--accent); text-decoration: none; }
 
-        a {
-            color: #00ffcc;
-            /* Change link color for better visibility */
-            text-decoration: underline;
-            /* Add underline for emphasis */
-        }
-    </style>
+    .footnote {
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 0.85rem;
+      border-top: 1px dashed var(--border);
+      padding-top: 12px;
+    }
+
+    code { color: var(--accent); }
+  </style>
 </head>
 
 <body>
-    <div class="container">
-        <div class="stars">
-            <!-- Generate stars dynamically using JavaScript -->
-            <script>
-                for (let i = 0; i < 150; i++) {
-                    let star = document.createElement("div");
-                    star.className = "star";
-                    star.style.top = Math.random() * 100 + "%";
-                    star.style.left = Math.random() * 100 + "%";
-                    star.style.animationDuration = (Math.random() * 1 + 0.5) + "s"; // Random duration between 0.5s and 1.5s
-                    document.querySelector(".stars").appendChild(star);
-                }
-            </script>
-        </div>
-        <div class="message">Redirecting to <a href="hanisntsolo-resume.pdf"
-                id="resumeLink">hanisntsolo-resume.pdf</a></div>
-    </div>
-    <script>
-        // Redirect after the animation
-        var redirectTimeout = setTimeout(function () {
-            window.location.href = "hanisntsolo-resume.pdf";
-        }, 3000); // Set to 3 seconds for the redirect to match the animation
+  <main class="card">
+    <h1>Dhirendra Pratap Singh</h1>
+    <p class="subtitle">
+      Full Stack Java Developer focused on distributed systems, cloud-native architecture, and product-minded engineering.
+    </p>
 
-        // Prevent redirect if the link is clicked
-        document.getElementById("resumeLink").onclick = function () {
-            clearTimeout(redirectTimeout); // Clear the redirect timeout
-        };
-    </script>
+    <div class="buttons">
+      <a class="btn primary" href="hanisntsolo-resume.pdf" id="downloadResume" download>
+        ⬇ Download Resume (PDF)
+      </a>
+      <a class="btn" href="hanisntsolo-resume.pdf" target="_blank" rel="noopener noreferrer" id="previewResume">
+        👀 Open in Browser
+      </a>
+    </div>
+
+    <div class="links">
+      <span><a href="https://hanisntsolo.com" target="_blank" rel="noopener noreferrer">Portfolio</a></span>
+      <span><a href="https://github.com/hanisntsolo" target="_blank" rel="noopener noreferrer">GitHub</a></span>
+      <span><a href="https://www.linkedin.com/in/hanisntsolo" target="_blank" rel="noopener noreferrer">LinkedIn</a></span>
+      <span><a href="mailto:ds.pratap1997@gmail.com">Email</a></span>
+    </div>
+
+    <p class="footnote">
+      Resume downloads tracked with GoatCounter. Total download clicks: <strong id="downloadCount">loading...</strong>
+    </p>
+  </main>
+
+  <script>
+    const DOWNLOAD_EVENT_PATH = '/resume-download';
+
+    function trackResumeDownload() {
+      if (window.goatcounter && typeof window.goatcounter.count === 'function') {
+        window.goatcounter.count({
+          path: DOWNLOAD_EVENT_PATH,
+          title: 'resume-download',
+          event: true
+        });
+      }
+    }
+
+    async function loadDownloadCount() {
+      const countEl = document.getElementById('downloadCount');
+
+      // GoatCounter public hit-counter endpoint for a path.
+      // If your site has public counters disabled, this can fail; then we show a fallback message.
+      const endpoint = 'https://hanisntsolo.goatcounter.com/counter/' + encodeURIComponent(DOWNLOAD_EVENT_PATH) + '.json';
+
+      try {
+        const resp = await fetch(endpoint, { mode: 'cors' });
+        if (!resp.ok) throw new Error('counter unavailable');
+        const data = await resp.json();
+        const count = data && typeof data.count === 'number' ? data.count : null;
+        countEl.textContent = count === null ? 'n/a' : count.toLocaleString();
+      } catch (err) {
+        countEl.textContent = 'available in GoatCounter dashboard';
+      }
+    }
+
+    document.getElementById('downloadResume').addEventListener('click', () => {
+      trackResumeDownload();
+    });
+
+    loadDownloadCount();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
### Motivation

- Wire the exact GoatCounter snippet (provided by the user) into the landing page and surface a download-count to show how many times the resume was downloaded.
- Provide a privacy-friendly, auditable download event path so clicks can be tracked centrally while handling cases where the public counter endpoint is restricted.

### Description

- Added the user-provided GoatCounter script tag to `index.html` to load GoatCounter for `hanisntsolo.goatcounter.com`.
- Implemented `trackResumeDownload()` that calls `window.goatcounter.count(...)` on the download button and uses a dedicated event path `/resume-download`.
- Added `loadDownloadCount()` which attempts to fetch `https://hanisntsolo.goatcounter.com/counter/%2Fresume-download.json` to display a `Total download clicks` value and falls back to a friendly message when the public counter is unavailable.
- Updated `README.md` analytics guidance to document the GoatCounter-first approach and note the public-counter visibility constraint.

### Testing

- Ran `git status --short` to confirm working tree changes (succeeded).
- Attempted to retrieve the GoatCounter client with `curl -sv https://hanisntsolo.goatcounter.com/count.js` which was blocked by the environment/proxy and returned `403 Forbidden` so external reachability could not be fully validated.
- Tried fetching GoatCounter counter endpoints from the container which returned no response (network restrictions), so the page fallback path was validated instead.
- Served the updated `index.html` with `python3 -m http.server 4173 --bind 0.0.0.0` and captured a Playwright screenshot of the page (succeeded), confirming the UI and event wiring were present on the landing page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb7d30c68832eb9eaf16384878f04)