### PR TITLE
Avoid overwriting LaTeX-generated PDFs in GitHub Actions deploy step

### DIFF
--- a/.github/workflows/compile-latex-hanisntsolo.yml
+++ b/.github/workflows/compile-latex-hanisntsolo.yml
@@ -59,7 +59,11 @@ jobs:
         run: npm run build
 
       - name: Copy site build to output
-        run: cp -r dist/* output/
+        run: |
+          find dist -mindepth 1 -maxdepth 1 \
+            ! -name 'hanisntsolo-resume.pdf' \
+            ! -name 'hanisntsolo-cover-letter.pdf' \
+            -exec cp -r {} output/ \;
 
       - name: Add CNAME file for Custom Domain
         run: echo "resume.hanisntsolo.com" > output/CNAME

--- a/.github/workflows/compile-latex-preview.yml
+++ b/.github/workflows/compile-latex-preview.yml
@@ -41,7 +41,11 @@ jobs:
         run: npm run build:preview
 
       - name: Copy site build to output
-        run: cp -r dist/* output/
+        run: |
+          find dist -mindepth 1 -maxdepth 1 \
+            ! -name 'hanisntsolo-resume.pdf' \
+            ! -name 'hanisntsolo-cover-letter.pdf' \
+            -exec cp -r {} output/ \;
 
       - name: Add CNAME file for Custom Domain
         run: echo "resume.hanisntsolo.com" > output/CNAME

--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -43,7 +43,11 @@ jobs:
         run: npm run build
 
       - name: Copy site build to output
-        run: cp -r dist/* output/
+        run: |
+          find dist -mindepth 1 -maxdepth 1 \
+            ! -name 'hanisntsolo-resume.pdf' \
+            ! -name 'hanisntsolo-cover-letter.pdf' \
+            -exec cp -r {} output/ \;
 
       - name: Add CNAME file for Custom Domain
         run: echo "hanisntsolo.hanisntsolo.com" > output/CNAME


### PR DESCRIPTION
### Motivation
- The deploy `cp -r dist/* output/` step failed with `Permission denied` because LaTeX jobs produce `output/hanisntsolo-cover-letter.pdf` before the site copy, creating a filename collision that the copy attempted to overwrite.

### Description
- Replace the brittle `cp -r dist/* output/` copy with a `find`-based copy that excludes `hanisntsolo-resume.pdf` and `hanisntsolo-cover-letter.pdf` to avoid overwriting LaTeX outputs.
- Apply the change to the three workflows: `.github/workflows/compile-latex-hanisntsolo.yml`, `.github/workflows/compile-latex.yml`, and `.github/workflows/compile-latex-preview.yml`.
- The new copy step uses `find dist -mindepth 1 -maxdepth 1 ! -name 'hanisntsolo-resume.pdf' ! -name 'hanisntsolo-cover-letter.pdf' -exec cp -r {} output/ \;` so non-PDF site assets are copied while preserving LaTeX-generated PDFs in `output/`.

### Testing
- Ran `npm run build` locally and the build completed successfully with the updated workflows executing the SEO generation step (succeeded). 
- Performed a simulated copy test that created a read-only `output/hanisntsolo-cover-letter.pdf` and confirmed the `find ... -exec cp -r` command copied site files without overwriting the existing PDF (succeeded).
- Verified the three workflow files were updated and lint/format diffs are limited to the copy step changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6a83b98c832eaf7e455eea91992f)